### PR TITLE
#3: Add detailed documentation for CLLM toolkit CLI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,6 @@ For more examples see the [examples](examples) directory.
 
 In addition to the `cllm` command, the `cllm` toolkit includes a suite of tools for interfacing with `cllm` output to build more complex prompt chaining processes.
 
-To learn more about the toolkit see the [toolkit](docs/toolkit/) documentation.
+To learn more about the toolkit see the [toolkit](docs/toolkit/README.md) documentation.
 
-See the [toolkit](docs/toolkit/) directory for more information on how to use the toolkit commands.
+For examples see the [examples](examples) directory.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# CLLM Toolkit Docs
+
+## Command Line Language Model (CLLM) Interface
+
+The Command Line Language Model (CLLM) Interface is a tool designed to facilitate interactions with language models via the command line. It provides various functionalities such as listing available systems and schemas, generating prompts from templates, and validating responses against schemas. [Details](cllm.md)
+
+## Command Line Language Model (CLLM) Toolkit
+
+The CLLM Toolkit is a collection of command-line tools designed to assist with various tasks such as text splitting, website scraping, FAISS indexing, code output, document splitting, file loading, image generation, and more. [Details](toolkit/README.md)

--- a/docs/toolkit/README.md
+++ b/docs/toolkit/README.md
@@ -1,0 +1,30 @@
+# Toolkit
+
+This toolkit consists of several command-line tools designed to assist with various tasks such as text splitting, website scraping, FAISS indexing, code output, document splitting, file loading, image generation, and more. Below is a brief overview of each tool:
+
+## Tools
+
+[cllm-splitter-text](cllm-splitter-text.md): A tool for splitting text into chunks using the RecursiveCharacterTextSplitter.
+
+cllm-load-website: A tool for scraping webpages and outputting their content in either text or HTML format.
+
+cllm-vector-faiss-write: A script for saving data to a FAISS index using OpenAI embeddings.
+
+cllm-output-code: A tool for processing and optionally installing dependencies for code provided via standard input.
+
+cllm-splitter-docs: A tool for splitting text documents into smaller chunks using the RecursiveCharacterTextSplitter.
+
+cllm-load-files: A tool for loading and splitting files into chunks.
+
+cllm-vector-faiss-load: A tool for performing similarity searches on a FAISS index using OpenAI embeddings.
+
+cllm-gen-dalle: A tool for generating images using OpenAI's DALL-E model.
+
+cllm-repeater: A tool for processing a list of data items by repeatedly invoking the cllm command with specified arguments.
+
+cllm-load-dir: A tool for loading files from a specified directory, splitting them into chunks, and optionally saving the processed data as a JSON file.
+
+cllm-load-sitemap: A script for generating a sitemap from a given URL using Selenium WebDriver.
+
+cllm-load-search-google: A tool for scraping Google search results based on specified queries and parameters.
+For detailed usage instructions and examples, please refer to the individual documentation files for each tool.

--- a/docs/toolkit/cllm-gen-dalle.md
+++ b/docs/toolkit/cllm-gen-dalle.md
@@ -1,69 +1,51 @@
-# `cllm-gen-dalle` Command Documentation
+# `cllm-gen-dalle` CLI Tool Documentation
 
-## Overview
-The `cllm-gen-dalle` command is a tool for generating images using OpenAI's DALL-E model. It allows users to specify various parameters such as model type, image size, quality, and number of images to generate. The generated images can be saved locally if an output directory is specified.
+`cllm-gen-dalle` is a command-line tool for generating images using OpenAI's DALL-E model. Below are the details on how to use the CLI arguments.
 
 ## Usage
+
 ```sh
 cllm-gen-dalle [OPTIONS]
 ```
 
 ## Options
-- `-m`, `--model` (type: `str`, default: `"dall-e-3"`): Specifies the model to use for image generation.
-- `-s`, `--size` (type: `str`, default: `"1024x1024"`): Specifies the size of the generated images. Valid options are `"256x256"`, `"512x512"`, and `"1024x1024"`.
-- `-q`, `--quality` (type: `str`, default: `"standard"`): Specifies the quality of the generated images. Valid options are `"low"`, `"standard"`, and `"high"`.
-- `-n`, `--number` (type: `int`, default: `1`): Specifies the number of images to generate per prompt. Must be at least `1`.
-- `-sp`, `--style` (type: `str`, default: `""`): Additional styling prompt to generate images from.
-- `-o`, `--output-dir` (type: `str`, default: `None`): Directory to save generated images.
 
-## Input
-The command reads JSON input from `stdin`, which should be a list of prompts for image generation.
+- `-m, --model <model>`: 
+  - **Description**: Specifies the model to use for image generation.
+  - **Default**: `dall-e-3`
+  - **Example**: `--model dall-e-2`
 
-## Output
-The command outputs a JSON array of URLs of the generated images. If an error occurs, it outputs a JSON object with an `error` key.
+- `-s, --size <size>`: 
+  - **Description**: Specifies the size of the generated images.
+  - **Default**: `1024x1024`
+  - **Valid Options**: `256x256`, `512x512`, `1024x1024`
+  - **Example**: `--size 512x512`
 
-## Example
-### Command
+- `-q, --quality <quality>`: 
+  - **Description**: Specifies the quality of the generated images.
+  - **Default**: `standard`
+  - **Valid Options**: `low`, `standard`, `high`
+  - **Example**: `--quality high`
+
+- `-n, --number <number>`: 
+  - **Description**: Specifies the number of images to generate per prompt.
+  - **Default**: `1`
+  - **Example**: `--number 3`
+
+- `-sp, --style <style>`: 
+  - **Description**: Additional styling prompt to generate images from.
+  - **Default**: `""` (empty string)
+  - **Example**: `--style "impressionist"`
+
+- `-o, --output-dir <output-dir>`: 
+  - **Description**: Directory to save generated images.
+  - **Default**: `None`
+  - **Example**: `--output-dir ./images`
+
+## Example Command
+
 ```sh
-echo '["A futuristic cityscape", "A serene mountain landscape"]' | cllm-gen-dalle -m "dall-e-3" -s "512x512" -q "high" -n 2 -sp "in the style of Van Gogh" -o "./output_images"
+echo '["A futuristic cityscape", "A serene mountain landscape"]' | cllm-gen-dalle --model dall-e-3 --style "cyberpunk"
 ```
 
-### Explanation
-- Generates 2 images for each prompt ("A futuristic cityscape" and "A serene mountain landscape") using the "dall-e-3" model.
-- The images are of size "512x512" and of "high" quality.
-- The images are styled "in the style of Van Gogh".
-- The generated images are saved in the `./output_images` directory.
-
-## Detailed Steps
-1. **Argument Parsing**: The command-line arguments are parsed using `argparse`.
-2. **Validation**: The provided arguments are validated to ensure they are within the acceptable range.
-3. **Reading Prompts**: The command reads JSON input from `stdin` to get the list of prompts.
-4. **Image Generation**: Asynchronously generates images for each prompt using the specified parameters.
-5. **Saving Images**: If an output directory is specified, the generated images are saved locally.
-6. **Output**: The URLs of the generated images are printed as a JSON array.
-
-## Error Handling
-- If the input JSON is invalid, an error message is logged and a JSON object with an `error` key is printed.
-- If any other error occurs during execution, it is logged and a JSON object with an `error` key is printed.
-
-## Logging
-The command uses the `logging` module to log information and errors. The log level can be set using the `LOGLEVEL` or `CLLM_LOGLEVEL` environment variables.
-
-## Dependencies
-- `openai`
-- `aiohttp`
-- `requests`
-- `argparse`
-- `asyncio`
-- `json`
-- `os`
-- `sys`
-- `logging`
-
-## Environment Variables
-- `LOGLEVEL` or `CLLM_LOGLEVEL`: Sets the logging level.
-
-## Notes
-- Ensure you have the necessary API keys and permissions to use OpenAI's DALL-E model.
-- The command requires an active internet connection to fetch the generated images.
-- Generating images costs API credits, so use the command judiciously.
+This command will generate images for the prompts "A futuristic cityscape" and "A serene mountain landscape" using the DALL-E 3 model, with a size of 512x512 pixels, high quality, and in a cyberpunk style. It will generate 2 images per prompt and save them in the `./generated_images` directory.

--- a/docs/toolkit/cllm-load-dir.md
+++ b/docs/toolkit/cllm-load-dir.md
@@ -1,78 +1,56 @@
-# cllm-load-dir: A Command-Line Tool for Loading and Processing Directory Files
+# cllm-load-dir CLI Tool Documentation
 
-## Overview
-
-`cllm-load-dir` is a command-line tool designed to load files from a specified directory, split the content into chunks, and convert the processed data into JSON format. The tool supports multithreading for efficient file loading and provides options to customize the chunk size and overlap.
-
-## Features
-
-- Load files from a specified directory using a glob pattern.
-- Split file content into chunks with customizable size and overlap.
-- Convert the processed data into JSON format.
-- Save the JSON data to a specified output file.
-- Support for multithreading to speed up file loading.
+`cllm-load-dir` is a command-line tool designed to load files from a specified directory, split them into chunks, and optionally save the processed data as a JSON file.
 
 ## Usage
 
-To use `cllm-load-dir`, you need to run the script with the appropriate arguments. Below is the detailed usage information.
-
-### Command-Line Arguments
-
-- `-d`, `--directory`: **(Required)** The directory to load files from.
-- `-g`, `--glob_pattern`: The glob pattern to match files. Default is `**/*`.
-- `-s`, `--chunk_size`: The size of each chunk. Default is `1000`.
-- `-o`, `--chunk_overlap`: The number of characters that overlap between chunks. Default is `10`.
-- `-m`, `--use_multithreading`: Use multithreading for loading files. Default is `True`.
-- `-f`, `--output_file`: The output file for the JSON data.
-
-### Example Command
-
-```bash
-cllm-load-dir -d /path/to/directory -g "*.txt" -s 500 -o 50 -m True -f output.json
+```sh
+cllm-load-dir -d <directory> [options]
 ```
 
-### Detailed Steps
+## Arguments
 
-1. **Load Files from Directory**:
-   The script uses the `DirectoryLoader` to load files from the specified directory based on the provided glob pattern.
+### Required Arguments
 
-2. **Split File Content**:
-   The content of the loaded files is split into chunks using the `RecursiveCharacterTextSplitter`. The chunk size and overlap can be customized.
+- `-d, --directory`
+  - **Type:** `str`
+  - **Description:** The directory to load files from.
+  - **Example:** `-d /path/to/directory`
 
-3. **Convert to JSON**:
-   The processed data is converted into JSON format using the `convert_docs_to_json` function.
+### Optional Arguments
 
-4. **Save JSON to File**:
-   If an output file is specified, the JSON data is saved to the file using the `save_json_to_file` function.
+- `-g, --glob_pattern`
+  - **Type:** `str`
+  - **Default:** `"**/*"`
+  - **Description:** The glob pattern to match files within the directory.
+  - **Example:** `-g "*.txt"`
 
-5. **Print JSON Data**:
-   The JSON data is printed to the console.
+- `-s, --chunk_size`
+  - **Type:** `int`
+  - **Default:** `1000`
+  - **Description:** The size of each chunk in characters.
+  - **Example:** `-s 500`
 
-## Example Output
+- `-o, --chunk_overlap`
+  - **Type:** `int`
+  - **Default:** `10`
+  - **Description:** The number of characters that overlap between chunks.
+  - **Example:** `-o 20`
 
-```json
-[
-  {
-    "page_content": "This is a chunk of text from the file.",
-    "metadata": {
-      "file_name": "example.txt",
-      "chunk_index": 0
-    }
-  },
-  {
-    "page_content": "This is another chunk of text from the file.",
-    "metadata": {
-      "file_name": "example.txt",
-      "chunk_index": 1
-    }
-  }
-]
+- `-m, --use_multithreading`
+  - **Action:** `store_true`
+  - **Description:** Use multithreading for loading files. This flag does not require a value.
+  - **Example:** `-m`
+
+- `-f, --output_file`
+  - **Type:** `str`
+  - **Description:** The output file path for the JSON data. If not provided, the JSON data will be printed to the console.
+  - **Example:** `-f output.json`
+
+## Example Command
+
+```sh
+cllm-load-dir -d /path/to/directory -g "*.txt" -s 500 -o 20 -m -f output.json
 ```
 
-## Logging
-
-The script uses Python's `logging` module to log messages. The log level can be set using the `LOGLEVEL` environment variable.
-
-## Conclusion
-
-`cllm-load-dir` is a versatile tool for loading, processing, and converting directory files into JSON format. With customizable options and support for multithreading, it is designed to handle various use cases efficiently.
+This command will load all `.txt` files from `/path/to/directory`, split them into chunks of 500 characters with an overlap of 20 characters, use multithreading for loading, and save the resulting JSON data to `output.json`.

--- a/docs/toolkit/cllm-load-files.md
+++ b/docs/toolkit/cllm-load-files.md
@@ -1,0 +1,27 @@
+# cllm-load-files CLI Tool Documentation
+
+## Usage
+
+The `cllm-load-files` CLI tool is designed to load and split files into chunks. Below are the details of the command-line arguments you can use with this tool.
+
+### Positional Arguments
+
+- `files` (str, optional): A JSON string representing the list of files to load. If not provided, the tool will read from standard input (stdin).
+
+### Optional Arguments
+
+- `-s`, `--chunk_size` (int, default=1000): Specifies the size of each chunk in characters. The default value is 1000 characters.
+  
+- `-o`, `--chunk_overlap` (int, default=10): Specifies the number of characters that overlap between consecutive chunks. The default value is 10 characters.
+
+### Example Usage
+
+```sh
+# Using positional argument for files
+cllm-load-files '["file1.txt", "file2.txt"]' -s 500 -o 20
+
+# Using stdin for files
+echo '["file1.txt", "file2.txt"]' | cllm-load-files -s 500 -o 20
+```
+
+This tool will output a JSON array of documents, where each document contains the `page_content` and `metadata` of the chunks created from the input files.

--- a/docs/toolkit/cllm-load-search-google.md
+++ b/docs/toolkit/cllm-load-search-google.md
@@ -1,0 +1,75 @@
+# cllm-load-search-google CLI Tool
+
+`cllm-load-search-google` is a command-line tool designed to scrape Google search results based on specified queries and parameters. Below is the documentation for the CLI arguments usage.
+
+## CLI Arguments
+
+### Positional Arguments
+
+- `query` (optional): 
+  - **Type**: `str`
+  - **Description**: The search query to be used for scraping Google search results. If not provided, the tool will read queries from standard input (stdin).
+  - **Default**: `""` (empty string)
+
+### Optional Arguments
+
+- `-t`, `--time_range`:
+  - **Type**: `TimeRange`
+  - **Choices**: `d` (day), `w` (week), `m` (month), `y` (year)
+  - **Description**: Specifies the time range for the search results.
+  - **Default**: `w` (week)
+
+- `-b`, `--browser`:
+  - **Type**: `str`
+  - **Choices**: `chrome`, `firefox`
+  - **Description**: Specifies the browser to use for scraping.
+  - **Default**: `firefox`
+
+- `-e`, `--exclude_list`:
+  - **Type**: `str`
+  - **nargs**: `+` (one or more values)
+  - **Description**: A list of domains to exclude from the search results.
+  - **Default**: `['google.com', 'youtube.com']`
+
+- `-l`, `--limit`:
+  - **Type**: `int`
+  - **Description**: The limit for the number of search results to return.
+  - **Default**: `20`
+
+### Example Usage
+
+```sh
+# Basic usage with a query
+cllm-load-search-google "example query"
+
+# Specifying a time range of one month
+cllm-load-search-google "example query" -t m
+
+# Using Chrome browser for scraping
+cllm-load-search-google "example query" -b chrome
+
+# Excluding specific domains from the results
+cllm-load-search-google "example query" -e example.com anotherexample.com
+
+# Limiting the number of results to 10
+cllm-load-search-google "example query" -l 10
+```
+
+### Reading Queries from Standard Input
+
+If no query is provided as a positional argument, the tool will read queries from standard input (stdin). This can be useful for batch processing multiple queries.
+
+```sh
+# Reading queries from a JSON file
+cat queries.json | cllm-load-search-google
+```
+
+In this example, `queries.json` should contain a JSON array of queries.
+
+```
+[
+    "query1",
+    "query2",
+    "query3"
+]
+```

--- a/docs/toolkit/cllm-load-sitemap.md
+++ b/docs/toolkit/cllm-load-sitemap.md
@@ -28,7 +28,7 @@ This script generates a sitemap from a given URL using Selenium WebDriver. It su
 ### Example
 
 ```sh
-cll-load-sitemap -u https://example.com -b chrome -l 2 -H
+cllm-load-sitemap -u https://example.com -b chrome -l 2 -H
 ```
 
 ## Logging

--- a/docs/toolkit/cllm-load-website.md
+++ b/docs/toolkit/cllm-load-website.md
@@ -1,0 +1,50 @@
+# cllm-load-website CLI Tool
+
+`cllm-load-website` is a command-line tool designed to scrape webpages and output their content in either text or HTML format. Below are the details on how to use the CLI arguments for this tool.
+
+## CLI Arguments
+
+### `-o`, `--output`
+- **Description**: Specify the output type.
+- **Usage**: Define the format of the output content. Acceptable values are `text` or `html`.
+- **Default**: `text`
+- **Example**: 
+  ```sh
+  cllm-load-website -o html
+  ```
+
+### `-b`, `--browser`
+- **Description**: Specify the browser type.
+- **Usage**: Choose the browser to be used for scraping. Acceptable values are `chrome` or `firefox`.
+- **Default**: `chrome`
+- **Example**: 
+  ```sh
+  cllm-load-website -b firefox
+  ```
+
+### `-u`, `--url`
+- **Description**: URL to scrape.
+- **Usage**: Provide a single URL to scrape. If not provided, the tool will read URLs from standard input.
+- **Example**: 
+  ```sh
+  cllm-load-website -u https://example.com
+  ```
+
+## Example Usage
+
+### Scraping a Single URL in Text Format Using Chrome
+```sh
+cllm-load-website -u https://example.com
+```
+
+### Scraping a Single URL in HTML Format Using Firefox
+```sh
+cllm-load-website -o html -b firefox -u https://example.com
+```
+
+### Reading URLs from Standard Input
+```sh
+echo '["https://example1.com", "https://example2.com"]' | cllm-load-website
+```
+
+By using these arguments, you can customize the behavior of the `cllm-load-website` tool to fit your specific scraping needs.

--- a/docs/toolkit/cllm-output-code.md
+++ b/docs/toolkit/cllm-output-code.md
@@ -1,0 +1,29 @@
+# cllm-output-code CLI Tool
+
+## Usage
+
+The `cllm-output-code` CLI tool provides a way to process and optionally install dependencies for code provided via standard input. Below are the available command-line arguments for this tool:
+
+### Arguments
+
+- `-s`, `--skip-dependencies`
+  - **Description**: Skip installing dependencies.
+  - **Usage**: Use this flag if you do not want the tool to install any dependencies specified in the input data.
+  - **Example**: 
+    ```sh
+    echo '{"code": "print(\"Hello, World!\")", "dependencies": ["requests"], "type": "python"}' | cllm-output-code -s
+    ```
+
+### Example Usage
+
+To run the tool without skipping dependencies:
+```sh
+echo '{"code": "print(\"Hello, World!\")", "dependencies": ["requests"], "type": "python"}' | cllm-output-code
+```
+
+To run the tool and skip installing dependencies:
+```sh
+echo '{"code": "print(\"Hello, World!\")", "dependencies": ["requests"], "type": "python"}' | cllm-output-code -s
+```
+
+In both examples, the input data is provided via standard input using `echo` and a pipe (`|`). The input data should be a JSON string containing the code, dependencies, and type.

--- a/docs/toolkit/cllm-repeater.md
+++ b/docs/toolkit/cllm-repeater.md
@@ -1,0 +1,35 @@
+# cllm-repeater CLI Tool
+
+`cllm-repeater` is a command-line tool designed to process a list of data items by repeatedly invoking the `cllm` command with specified arguments. The tool reads input data from standard input, processes each item, and outputs the results in JSON format.
+
+## Usage
+
+```sh
+cllm-repeater [args...]
+```
+
+### Arguments
+
+- `[args...]`: A list of arguments to be passed to the `cllm` command. These arguments are appended to the `cllm` command for each item in the input data.
+
+### Input
+
+The input data should be provided via standard input (stdin) in JSON format. The JSON should be an array of items, where each item is a string that will be passed to the `cllm` command.
+
+### Output
+
+The output is a JSON array where each element corresponds to the result of processing an item from the input data. The results can be either parsed JSON objects (if the `cllm` command outputs valid JSON) or raw strings (if the output is not valid JSON). In case of a `FileNotFoundError`, the error message will be included in the output.
+
+### Example
+
+```sh
+echo '["Party ideas", "Places to see"]' | cllm-repeater -s list gpt/3.5
+```
+
+In this example, the input data `["data1", "data2"]` is processed by the `cllm` command with the arguments `--option1 value1 --option2 value2`. The results are then printed in JSON format.
+
+### Notes
+
+- Ensure that the `cllm` command is available in your system's PATH.
+- The tool captures both standard output and standard error from the `cllm` command.
+- If the `cllm` command is not found, an error message will be included in the output.

--- a/docs/toolkit/cllm-splitter-docs.md
+++ b/docs/toolkit/cllm-splitter-docs.md
@@ -1,0 +1,61 @@
+# CLLM Splitter Docs CLI Tool
+
+## Overview
+The `cllm-splitter-docs` CLI tool is designed to split text documents into smaller chunks using the `RecursiveCharacterTextSplitter`. This can be useful for processing large texts in manageable pieces, with optional overlap between chunks.
+
+## Usage
+
+### Command Line Arguments
+
+- `-s`, `--chunk_size`
+  - **Type:** `int`
+  - **Default:** `1000`
+  - **Description:** Specifies the maximum size of each chunk in characters. This determines how large each split text segment will be.
+
+- `-o`, `--chunk_overlap`
+  - **Type:** `int`
+  - **Default:** `10`
+  - **Description:** Specifies the number of characters that overlap between consecutive chunks. This can help maintain context between chunks.
+
+### Example
+
+To split a document with a chunk size of 500 characters and an overlap of 50 characters, you would use the following command:
+
+```sh
+cllm-splitter-docs -s 500 -o 50
+```
+
+This will read the input documents from standard input, split them according to the specified chunk size and overlap, and print the resulting chunks in JSON format.
+
+## Input and Output
+
+- **Input:** The tool expects a JSON array of documents from standard input. Each document should be a dictionary with at least a `"page_content"` key containing the text to be split.
+- **Output:** The tool outputs a JSON array of documents to standard output, where each document contains a chunk of the original text and its associated metadata.
+
+## Example Input
+
+```json
+[
+  {
+    "page_content": "This is a long text document that needs to be split into smaller chunks.",
+    "metadata": {"title": "Example Document"}
+  }
+]
+```
+
+## Example Output
+
+```json
+[
+  {
+    "page_content": "This is a long text document that needs to be split into smaller",
+    "metadata": {"title": "Example Document"}
+  },
+  {
+    "page_content": "chunks.",
+    "metadata": {"title": "Example Document"}
+  }
+]
+```
+
+By using the `cllm-splitter-docs` CLI tool, you can efficiently manage and process large text documents by breaking them down into smaller, more manageable pieces.

--- a/docs/toolkit/cllm-splitter-text.md
+++ b/docs/toolkit/cllm-splitter-text.md
@@ -1,0 +1,45 @@
+# cllm-splitter-text CLI Tool Documentation
+
+## Overview
+`cllm-splitter-text` is a command-line tool designed to split text into chunks using the `RecursiveCharacterTextSplitter`. This tool is useful for processing large texts by breaking them down into smaller, manageable pieces with optional overlapping characters and associated metadata.
+
+## Usage
+```sh
+cllm-splitter-text [OPTIONS]
+```
+
+## Options
+
+### `-s, --chunk_size`
+- **Description**: Specifies the maximum size of each chunk.
+- **Type**: `int`
+- **Default**: `100`
+- **Example**: 
+  ```sh
+  cllm-splitter-text -s 150
+  ```
+
+### `-o, --chunk_overlap`
+- **Description**: Specifies the number of characters that overlap between chunks.
+- **Type**: `int`
+- **Default**: `20`
+- **Example**: 
+  ```sh
+  cllm-splitter-text -o 30
+  ```
+
+### `-m, --metadata`
+- **Description**: Provides metadata to be associated with each chunk. The metadata should be in JSON format.
+- **Type**: `json.loads`
+- **Default**: `'{}'`
+- **Example**: 
+  ```sh
+  cllm-splitter-text -m '{"author": "John Doe", "date": "2023-10-01"}'
+  ```
+
+## Example Command
+```sh
+echo "Your large text here" | cllm-splitter-text -s 150 -o 30 -m '{"author": "John Doe"}'
+```
+
+This command reads the text from standard input, splits it into chunks of up to 150 characters with 30 characters overlapping between chunks, and associates the metadata `{"author": "John Doe"}` with each chunk. The resulting chunks are then printed in JSON format.


### PR DESCRIPTION
- Updated README.md to correct links and improve clarity.
- Added comprehensive documentation for the following CLI tools:
  - cllm-gen-dalle: Instructions for generating images using OpenAI's DALL-E model.
  - cllm-load-dir: Guide for loading and processing files from a directory.
  - cllm-load-files: Details on loading and splitting files into chunks.
  - cllm-load-search-google: Instructions for scraping Google search results.
  - cllm-load-sitemap: Corrected example command and added usage details.
  - cllm-load-website: Guide for scraping webpages and outputting content.
  - cllm-output-code: Instructions for processing code and installing dependencies.
  - cllm-repeater: Guide for processing data items by invoking the cllm command.
  - cllm-splitter-docs: Instructions for splitting text documents into chunks.
  - cllm-splitter-text: Guide for splitting text into chunks with metadata.