### PR TITLE
#17 feat: Add support for Groq and Ollama model providers

### DIFF
--- a/.cllm/systems/base.yml
+++ b/.cllm/systems/base.yml
@@ -1,3 +1,4 @@
 model: gpt-4o
-description: A basic system. No system prompt is provided.
+provider: openai
+description: GPT-4o model provided by OpenAI
 temperature: 0

--- a/.cllm/systems/gpt/3.5.yml
+++ b/.cllm/systems/gpt/3.5.yml
@@ -1,3 +1,4 @@
 model: gpt-3.5-turbo
-description: A basic system. No system prompt is provided.
+provider: openai
+description: OpenAI gpt-3.5-turbo for general purpose.
 temperature: 0

--- a/.cllm/systems/gpt/4.yml
+++ b/.cllm/systems/gpt/4.yml
@@ -1,3 +1,4 @@
 model: gpt-4-turbo
-description: A basic system. No system prompt is provided.
+provider: openai
+description: OpenAI gpt-4-turbo for general purpose.
 temperature: 0

--- a/.cllm/systems/gpt/4o.yml
+++ b/.cllm/systems/gpt/4o.yml
@@ -1,3 +1,4 @@
 model: gpt-4o
-description: A basic system. No system prompt is provided.
+provider: openai
+description: OpenAI gpt-4o for general purpose.
 temperature: 0

--- a/.cllm/systems/groq/gemma.yml
+++ b/.cllm/systems/groq/gemma.yml
@@ -1,0 +1,4 @@
+model: gemma-7b-it
+provider: groq
+description: Gemma 7b model provided by Groq
+temperature: 0

--- a/.cllm/systems/groq/llama.yml
+++ b/.cllm/systems/groq/llama.yml
@@ -1,0 +1,4 @@
+model: llama3-70b-8192
+provider: groq
+description: Llama3 70b model provided by Groq
+temperature: 0

--- a/.cllm/systems/groq/mixtral.yml
+++ b/.cllm/systems/groq/mixtral.yml
@@ -1,0 +1,4 @@
+model: mixtral-8x7b-32768
+provider: groq
+description: Mixtral 8x7b model provided by Groq
+temperature: 0

--- a/.cllm/systems/l/llama.yml
+++ b/.cllm/systems/l/llama.yml
@@ -1,4 +1,4 @@
 model: llama3
-description: A system that uses a local llm model for generating responses.
+provider: ollama
+description: Llama3 7b model locally provided by Ollama 
 temperature: 0
-base_url: http://localhost:11434/v1

--- a/.cllm/systems/l/phi.yml
+++ b/.cllm/systems/l/phi.yml
@@ -1,4 +1,4 @@
 model: phi3
-description: A system that uses a local llm model for generating responses.
+provider: ollama
+description: Phi3 7b model locally provided by Ollama
 temperature: 0
-base_url: http://localhost:11434/v1

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The `cllm` toolkit attempts to solve these issues by being bash centric. Allowin
 
 - jq
 - Ollama
+- Groq API Key set as `GROQ_API_KEY` environment variable
 
 ## Note
 
@@ -117,3 +118,13 @@ For more examples see the [examples](examples) directory.
 In addition to the `cllm` command, the `cllm` toolkit includes a suite of tools for interfacing with `cllm` output to build more complex prompt chaining processes.
 
 To learn more about the toolkit see the [toolkit](docs/toolkit/README.md) documentation.
+
+
+## LLM Model Provides
+
+The `cllm` command currently supports the following models providers:
+
+- OpenAI - https://platform.openai.com/docs/introduction
+- Ollama - https://www.ollama.com/
+- Groq - https://groq.com/
+

--- a/docs/cllm.md
+++ b/docs/cllm.md
@@ -2,13 +2,14 @@
 
 The Command Line Language Model (CLLM) Interface is a tool designed to facilitate interactions with language models via the command line. It provides various functionalities such as listing available systems and schemas, generating prompts from templates, and validating responses against schemas.
 
+
 ## Usage
 
 To use the CLLM interface, you can run the `cllm` command followed by the appropriate arguments and options. Below is a detailed explanation of the available commands and options.
 
 ### Commands
 
-- `list`: Lists all available systems.
+- `systems`: Lists all available systems.
 - `schemas`: Lists all available schemas.
 
 if one of the built-in commands is not found, `cllm` will attempt to run the command as a system. System configurations are stored in the $CLLM_PATH/systems directory.
@@ -50,10 +51,28 @@ temperature: 0
 
 By default `cllm` expects that a `.cllm` folder exists in the current working directory. This folder should contain the `systems`, `templates` and `schemas` directories. You can override this by setting the `CLLM_PATH` environment variable.
 
-#### Listing Available Systems
+#### Systems Files
+
+The system files are stored in the $CLLM_PATH/systems directory. The system files are YAML files that contain the configuration for the system.
+
+Example:
+
+`$CLLM_PATH/systems/base.yml`
+
+```yaml
+
+model: gpt-4o
+provider: openai
+description: A basic system. No system prompt is provided.
+system_prompt: A system prompt is provided.
+temperature: 0
+
+```
+
+### Listing Available Systems
 
 ```bash
-cllm list
+cllm systems
 ```
 
 #### Listing Available Schemas
@@ -67,6 +86,7 @@ cllm schemas
 ```bash
 cllm gpt/3.5 -pi "Who are the members of the Beatles?"
 ```
+
 
 ## Persistent Context
 


### PR DESCRIPTION
- Updated `.cllm/systems` configurations to include new model providers: Groq and Ollama.
- Added new system files for Groq models: `gemma.yml`, `llama.yml`, and `mixtral.yml`.
- Modified existing system files to include the `provider` field and updated descriptions.
- Updated `README.md` to include Groq API key requirement and list supported model providers.
- Refactored `cllm.py` to:
  - Add base URLs for Groq and Ollama.
  - Implement client retrieval functions for OpenAI, Ollama, and Groq.
  - Update the `systems` command to list available systems with provider information.
  - Introduce a `get_client` function to dynamically select the appropriate client based on the provider.
- Updated `docs/cllm.md` to reflect changes in command usage and system file structure.

closes #17