### PR TITLE
Add cllm-prompt CLI tool for generating prompts using Jinja2 templates

### DIFF
--- a/cllm/toolkit/prompt.py
+++ b/cllm/toolkit/prompt.py
@@ -1,0 +1,81 @@
+import argparse
+import os
+import sys
+from pathlib import Path
+from jinja2 import Environment, FileSystemLoader
+from tabulate import tabulate
+import yaml
+import logging
+from typing import Dict, Any
+from cllm.constants import *
+
+# Constants
+TEMPLATES_DIR = "templates"
+TEMPLATE_FILE_EXTENSION = ".tpl"
+DEFAULT_TEMPLATE = "default"
+
+# Configure logging
+logging.basicConfig(level=os.environ.get("CLLM_LOGLEVEL"))
+logger = logging.getLogger(__name__)
+
+def list_available_items(directory: str, headers: list) -> None:
+    """List available items in a directory and print them in a table format."""
+    table_data = []
+    for path in [str(f) for f in Path(directory).rglob('*') if f.is_file()]:
+        name = path.replace(f"{directory}/", "").replace(TEMPLATE_FILE_EXTENSION, "")
+        table_data.append(name)
+    print(table_data)
+
+def generate_prompt_from_template(template_name: str, cllm_dir: str, context: Dict[str, Any]) -> str:
+    """Generate a prompt from a Jinja2 template."""
+    template_env = Environment(loader=FileSystemLoader(f"{cllm_dir}/{TEMPLATES_DIR}"))
+    template = template_env.get_template(f"{template_name}.tpl")
+    return template.render(**context)
+
+def build_cllm_prompt(template: str, cllm_dir: str, context: Dict[str, Any]) -> str:
+    """Build the CLLM prompt based on the provided template and context."""
+    return generate_prompt_from_template(template, cllm_dir, context)
+
+def handle_templates_command(cllm_dir: str) -> None:
+    """Handle the 'templates' command by listing available templates."""
+    print("Available templates:")
+    list_available_items(f"{cllm_dir}/{TEMPLATES_DIR}", ["name"])
+    sys.exit(0)
+
+def main() -> None:
+    """Main entry point for the Template CLI."""
+    parser = argparse.ArgumentParser(description="Template CLI for generating prompts")
+    parser.add_argument("-t", "--template", help="Template name", default='default')
+    parser.add_argument("-l", "--list", help="List available templates", action="store_true")
+    parser.add_argument("-pr", "--prompt-role", help="Specify the role prompt", default=PROMPT_ROLE)
+    parser.add_argument("-pi", "--prompt-instructions", help="Specify the instructions prompt", default=PROMPT_INSTRUCTIONS)
+    parser.add_argument("-pc", "--prompt-context", help="Specify the context prompt", default=PROMPT_CONTEXT)
+    parser.add_argument("-po", "--prompt-output", help="Specify the output prompt", default=PROMPT_OUTPUT)
+    parser.add_argument("-pe", "--prompt-example", help="Specify the example prompt", default=PROMPT_EXAMPLE)
+    parser.add_argument("--cllm-dir", help="Path to the cllm directory", default=CLLM_DIR)
+    parser.add_argument("prompt_input", nargs='?', help="Input for the prompt", default=PROMPT_INPUT)
+    
+    args = parser.parse_args()
+
+    context = {
+        "PROMPT_ROLE": args.prompt_role,
+        "PROMPT_INSTRUCTIONS": args.prompt_instructions,
+        "PROMPT_CONTEXT": args.prompt_context,
+        "PROMPT_OUTPUT": args.prompt_output,
+        "PROMPT_EXAMPLE": args.prompt_example,
+        "PROMPT_INPUT": args.prompt_input,
+        "PROMPT_STDIN": None
+    }
+
+    if not sys.stdin.isatty():
+        context['PROMPT_STDIN'] = sys.stdin.read().strip()
+
+    if args.list:
+        handle_templates_command(args.cllm_dir)
+        exit(0)
+   
+    prompt = build_cllm_prompt(args.template, args.cllm_dir, context)
+    print(prompt)
+
+if __name__ == '__main__':
+    main()

--- a/docs/toolkit/cllm-prompt.md
+++ b/docs/toolkit/cllm-prompt.md
@@ -1,0 +1,164 @@
+# CLLM-Prompt Command Documentation
+
+The `cllm-prompt` command is a command-line interface (CLI) tool designed to generate prompts using Jinja2 templates. This tool allows users to create customized prompts by specifying various context parameters and templates.
+
+## Usage
+
+To use the `cllm-prompt` command, you can run it with the appropriate arguments and options. Below is a detailed explanation of the available commands and options.
+
+### Commands
+
+- `templates`: Lists all available templates.
+
+### Options
+
+- `-t, --template`: Define a prompt template. Default is `default`.
+- `-l, --list`: List available templates.
+- `-pr, --prompt-role`: Specify the role prompt. Default is `PROMPT_ROLE`.
+- `-pi, --prompt-instructions`: Specify the instructions prompt. Default is `PROMPT_INSTRUCTIONS`.
+- `-pc, --prompt-context`: Specify the context prompt. Default is `PROMPT_CONTEXT`.
+- `-po, --prompt-output`: Specify the output prompt. Default is `PROMPT_OUTPUT`.
+- `-pe, --prompt-example`: Specify the example prompt. Default is `PROMPT_EXAMPLE`.
+- `--cllm-dir`: Path to the CLLM directory. Default is `CLLM_DIR`.
+- `prompt_input`: Input for the prompt. Default is `PROMPT_INPUT`.
+
+### Example Usage
+
+By default, `cllm-prompt` expects that a `.cllm` folder exists in the specified directory. This folder should contain the `templates` directory. You can override this by setting the `CLLM_DIR` environment variable.
+
+#### Listing Available Templates
+
+To list all available templates, use the `--list` option:
+
+```bash
+cllm-prompt --list
+```
+
+#### Generating a Prompt with Default Template
+
+To generate a prompt using the default template, you can run:
+
+```bash
+cllm-prompt -pi "Who are the members of the Beatles?"
+```
+
+#### Generating a Prompt with a Custom Template
+
+To generate a prompt using a custom template, specify the template name with the `-t` option:
+
+```bash
+cllm-prompt -t custom_template -pi "Who are the members of the Beatles?"
+```
+
+#### Providing Additional Context
+
+You can provide additional context for the prompt using the `--prompt-context` option:
+
+```bash
+cllm-prompt -pc "I want to know more about British rock." -pi "Who are the members of the Beatles?"
+```
+
+### Environment Variables
+
+You can also set environment variables to provide default values for the options.
+
+- `CLLM_TEMPLATE`
+- `CLLM_PROMPT_ROLE`
+- `CLLM_PROMPT_INSTRUCTIONS`
+- `CLLM_PROMPT_CONTEXT`
+- `CLLM_PROMPT_OUTPUT`
+- `CLLM_PROMPT_EXAMPLE`
+- `CLLM_DIR`
+- `CLLM_PROMPT_INPUT`
+
+### Example with Environment Variables
+
+```bash
+export CLLM_TEMPLATE="default"
+export CLLM_PROMPT_INSTRUCTIONS="These are the instructions"
+cllm-prompt
+```
+
+### Variable Precedence
+
+The order of precedence for variables is as follows:
+
+1. Command line options
+2. Environment variables
+3. Default values
+
+## Prompt Templating
+
+The prompt variables are broken down into the following categories:
+
+- `PROMPT_ROLE`: Tells the model who to be.
+- `PROMPT_INSTRUCTIONS`: Instructions about what you want the model to do.
+- `PROMPT_CONTEXT`: Background context or additional information for the prompt.
+- `PROMPT_OUTPUT`: Tell the model what you want the output to be.
+- `PROMPT_EXAMPLE`: Provides the model with an example of what you want the output to look like.
+
+### Default Template
+
+The `default` template is found in the `$CLLM_DIR/templates/default.tpl` file, which looks like this:
+
+```
+{% if (PROMPT_CONTEXT or PROMPT_STDIN) %}
+CONTEXT:
+{{PROMPT_CONTEXT or ""}} 
+{{PROMPT_STDIN or ""}}
+{% endif %}
+{% if PROMPT_ROLE %}
+ROLE:
+{{PROMPT_ROLE}}
+{% endif %}
+INSTRUCTIONS:
+{{PROMPT_INSTRUCTIONS or ""}}
+{{PROMPT_INPUT or ""}}
+{% if PROMPT_OUTPUT %}
+OUTPUT:
+{{PROMPT_OUTPUT}}
+{% endif %}
+{% if PROMPT_EXAMPLE %}
+EXAMPLE:
+{{PROMPT_EXAMPLE}}
+{% endif %}
+```
+
+### Custom Templates
+
+You can add custom templates by creating a new `.tpl` file in the `$CLLM_DIR/templates` directory.
+
+### Example with Custom Template
+
+The `qa` template is found in the `$CLLM_DIR/templates/qa.tpl` file:
+
+```
+{% if PROMPT_ROLE %}
+ROLE:
+{{PROMPT_ROLE}}
+{% endif %}
+
+QUESTION:
+{{PROMPT_CONTEXT or ""}} 
+{{PROMPT_STDIN or ""}}
+{{PROMPT_INSTRUCTIONS or ""}}
+{{PROMPT_INPUT or ""}}
+
+ANSWER:
+```
+
+Using the `qa` template:
+
+```bash
+cllm-prompt -t qa -pc "I want to know more about British rock." -pi "Who are the members of the Beatles?"
+```
+
+Stdin can be used to provide additional context. Instructions can be passed to the model using quoted strings like this:
+
+```bash
+echo "I want to know more about British rock." | cllm-prompt -t qa -pi "Who are the members of the Beatles?"
+```
+
+## Conclusion
+
+The `cllm-prompt` command provides a flexible and powerful way to generate prompts using templates. By leveraging the options and environment variables, you can customize the prompts to fit your specific needs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
 cllm = 'cllm.cllm:main'
+cllm-prompt = 'cllm.toolkit.prompt:main'
 cllm-gen-dalle = 'cllm.toolkit.gen_dalle:main'
 cllm-load-dir = 'cllm.toolkit.load_dir:main'
 cllm-load-files = 'cllm.toolkit.load_files:main'


### PR DESCRIPTION
- Introduced a new CLI tool `cllm-prompt` in `cllm/toolkit/prompt.py` for generating prompts using Jinja2 templates.
- Added functionality to list available templates and generate prompts based on specified context parameters.
- Configured logging and argument parsing for the CLI tool.
- Created documentation for `cllm-prompt` in `docs/toolkit/cllm-prompt.md`, detailing usage, options, and examples.
- Updated `pyproject.toml` to include `cllm-prompt` as a script entry point.

This enhancement provides a flexible and powerful way to generate customized prompts, improving the usability and functionality of the toolkit.

closes #28