### PR TITLE
#22 Add support for image prompts and refactor code

### DIFF
--- a/docs/cllm.md
+++ b/docs/cllm.md
@@ -44,6 +44,7 @@ temperature: 0
 - `--cllm-dir`: Path to the CLLM directory. Default is the current working directory with `.cllm` appended.
 - `--cllm-trace-id`: Specify a trace ID.
 - `--max-messages`: Limit the number of saved messages in the chat context.
+- `--image`: Specify an image file path or URL to include in the prompt.
 - `prompt_input`: Input for the prompt.
 
 ### Example Usage
@@ -83,6 +84,18 @@ cllm schemas
 ```bash
 cllm gpt/3.5 -pi "Who are the members of the Beatles?"
 ```
+
+### Including Images in Prompts
+
+You can now include images in your prompts using the `--image` option. The image can be specified as a file path or a URL.
+
+```bash
+cllm gpt/4o -pi "Describe this image." --image /path/to/image.jpg
+```
+
+If the image is a file, it will be encoded to base64 and included in the prompt.
+
+**Note:** Not all models support image prompts. Check the model documentation for compatibility.
 
 ## Persistent Context
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cllm"
-version = "0.1.2"
+version = "0.1.3"
 description = "LLM Prompt Chaining in Bash"
 authors = ["owen.zanzal <ozanzal@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
- Introduced the ability to include images in prompts using the `--image` option.
  - Images can be specified as file paths or URLs.
  - If the image is a file, it will be encoded to base64 and included in the prompt.
- Added `base64` import for encoding image files.
- Removed unused BASE_URL_GROQ and BASE_URL_OLLAMA constants.
- Added `is_file` function to check if a file exists.
- Updated the `cllm` function to handle image prompts.
- Updated the CLI argument parser to include the `--image` option.
- Updated documentation to reflect the new `--image` option.
- Bumped version to 0.1.3 in `pyproject.toml`.