### PR TITLE
#27 Add audio recording and speech-to-text functionality

### DIFF
--- a/cllm/cllm.py
+++ b/cllm/cllm.py
@@ -99,6 +99,7 @@ def cllm(command: str,
          schema: Optional[str], 
          chat_context: Optional[str],
          chat_context_path: Optional[str],
+         disable_chat_context_write: Optional[bool],
          prompt_primer: Optional[str], 
          prompt_system: Optional[str], 
          prompt_role: Optional[str],
@@ -230,7 +231,7 @@ def cllm(command: str,
             if schema:
                 validate_response_with_schema(response_message, schema_config.get('schema'))
             
-        if chat_context:
+        if chat_context and not disable_chat_context_write:
             messages.append({"role": "assistant", "content": response_message})
             if max_messages is not None and len(messages) > max_messages:
                 messages = messages[-max_messages:]
@@ -248,12 +249,13 @@ def main() -> None:
     """Main entry point for the CLLM command-line interface."""
     parser = argparse.ArgumentParser(description="Command Line Language Model (CLLM) Interface")
     parser.add_argument("command", nargs='?',
-                        help="Command to execute", 
+                        help="Command to execute",
                         default=COMMAND)
     parser.add_argument("-t", "--template", help="Define a prompt template", default=TEMPLATE)
     parser.add_argument("-s", "--schema", help="Specify the schema file", default=SCHEMA)
     parser.add_argument("-c", "--chat-context", help="Specify the chat context", default=CHAT_CONTEXT)
     parser.add_argument("-cp", "--chat-context-path", help="Specify the chat context path", default=None)
+    parser.add_argument("--disable-chat-context-write", action="store_true", help="Disable writing to the chat context")
     parser.add_argument("-pp", "--prompt-primer", help="Primer prompt input", default=PROMPT_PRIMER)
     parser.add_argument("-ps", "--prompt-system", help="Specify the system prompt", default=PROMPT_SYSTEM)
     parser.add_argument("-pr", "--prompt-role", help="Specify the role prompt", default=PROMPT_ROLE)
@@ -292,7 +294,8 @@ def main() -> None:
         "cllm_trace_id": args.cllm_trace_id,
         "dry_run": args.dry_run,
         "max_messages": args.max_messages,
-        "streaming": args.streaming
+        "streaming": args.streaming,
+        "disable_chat_context_write": args.disable_chat_context_write
     }
 
     if not sys.stdin.isatty():

--- a/cllm/toolkit/listen.py
+++ b/cllm/toolkit/listen.py
@@ -1,0 +1,123 @@
+import argparse
+import tempfile
+import queue
+import sys
+import numpy as np
+import sounddevice as sd
+import soundfile as sf
+from cllm.constants import *
+
+def int_or_str(text):
+    """Helper function for argument parsing."""
+    try:
+        return int(text)
+    except ValueError:
+        return text
+
+class AudioRecorder:
+    def __init__(self, args):
+        self.args = args
+        self.q = queue.Queue()
+        self.recording_started = False
+        self.below_threshold_start_time = None
+        self.finished_recording = False
+
+    def callback(self, indata, frames, time, status):
+        """Callback function for audio input stream."""
+        if status:
+            print(status, file=sys.stderr)
+        volume_norm = np.linalg.norm(indata)
+        current_time = time.inputBufferAdcTime
+
+        if self.should_start_recording(volume_norm):
+            self.start_recording(current_time)
+
+        if self.recording_started:
+            self.q.put(indata.copy())
+
+        if self.should_stop_recording(volume_norm, current_time):
+            self.stop_recording()
+
+    def should_start_recording(self, volume_norm):
+        """Check if recording should start based on volume threshold."""
+        return volume_norm >= self.args.threshold and not self.recording_started
+
+    def start_recording(self, current_time):
+        """Start the recording process."""
+        self.recording_started = True
+        self.below_threshold_start_time = current_time
+
+    def should_stop_recording(self, volume_norm, current_time):
+        """Check if recording should stop based on volume threshold and duration."""
+        return (self.recording_started and volume_norm <= self.args.threshold and
+                current_time - self.below_threshold_start_time >= self.args.stop_threshold_duration)
+
+    def stop_recording(self):
+        """Stop the recording process."""
+        self.recording_started = False
+        self.finished_recording = True
+        raise sd.CallbackStop()
+
+    def start(self):
+        """Start the audio recording process."""
+        try:
+            self.setup_audio_file()
+            self.record_audio()
+        except (Exception, KeyboardInterrupt, sd.CallbackStop) as e:
+            self.handle_recording_exception(e)
+
+    def setup_audio_file(self):
+        """Setup the audio file for recording."""
+        if self.args.samplerate is None:
+            device_info = sd.query_devices(self.args.device, 'input')
+            self.args.samplerate = int(device_info['default_samplerate'])
+        if self.args.filename is None:
+            if not os.path.exists(self.args.temp_dir):
+                os.makedirs(self.args.temp_dir)
+            self.args.filename = tempfile.mktemp(prefix=f"{self.args.temp_prefix}_", suffix='.wav', dir=self.args.temp_dir)
+
+    def record_audio(self):
+        """Record audio until finished."""
+        with sf.SoundFile(self.args.filename, mode='x', samplerate=self.args.samplerate,
+                          channels=self.args.channels, subtype=self.args.subtype) as file:
+            with sd.InputStream(samplerate=self.args.samplerate, device=self.args.device,
+                                channels=self.args.channels, callback=self.callback):
+                while not self.finished_recording:
+                    file.write(self.q.get())
+                print(f"{self.args.filename}")
+
+
+    def handle_recording_exception(self, e):
+        """Handle exceptions during recording."""
+        print(f"An error occurred during recording: {e}")
+        print(f"{self.args.filename}")
+
+def parse_arguments():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument('-l', '--list-devices', action='store_true', help='show list of audio devices and exit')
+    args, remaining = parser.parse_known_args()
+    if args.list_devices:
+        print(sd.query_devices())
+        parser.exit(0)
+
+    parser = argparse.ArgumentParser(description="Audio Recorder", parents=[parser])
+    parser.add_argument('filename', nargs='?', metavar='FILENAME', help='audio file to store recording to')
+    parser.add_argument('-d', '--device', type=int_or_str, help='input device (numeric ID or substring)')
+    parser.add_argument('-r', '--samplerate', type=int, help='sampling rate')
+    parser.add_argument('-c', '--channels', type=int, default=1, help='number of input channels')
+    parser.add_argument('-t', '--subtype', type=str, help='sound file subtype (e.g. "PCM_24")')
+    parser.add_argument('--threshold', type=float, default=0.7, help='volume threshold to start recording')
+    parser.add_argument('--stop-threshold-duration', type=float, default=2.0, help='duration in seconds the volume must be below threshold to stop recording')
+    parser.add_argument('--temp-dir', type=str, default=f"{CLLM_DIR}/recordings", help='directory for temporary files')
+    parser.add_argument('--temp-prefix', type=str, default='voice_chat', help='prefix for temporary files')
+    return parser.parse_args(remaining)
+
+def main():
+    """Main function to run the audio recorder."""
+    args = parse_arguments()
+    recorder = AudioRecorder(args)
+    recorder.start()
+
+if __name__ == "__main__":
+    main()

--- a/cllm/toolkit/speech_text.py
+++ b/cllm/toolkit/speech_text.py
@@ -1,0 +1,30 @@
+import argparse
+from litellm import transcription
+from cllm.constants import *
+
+def parse_arguments():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Speech to Text CLI tool using LiteLLM")
+    parser.add_argument("-f", "--audio_file", required=True, default="", help="Path to the audio file for transcription")
+    parser.add_argument("-m", "--model", default="whisper-1", help="Model to use for transcription (default: whisper-1)")
+    return parser.parse_args()
+
+def transcribe_audio(audio_file_path, model):
+    """Transcribe the audio file using the specified model."""
+    try:
+        with open(audio_file_path, "rb") as audio_file:
+            response = transcription(model=model, file=audio_file)
+            return response.text
+    except FileNotFoundError:
+        return f"Error: Audio file not found: {audio_file_path}"
+    except Exception as e:
+        return f"Error during transcription: {str(e)}"
+
+def main():
+    """Main function to run the transcription process."""
+    args = parse_arguments()
+    transcription_result = transcribe_audio(args.audio_file, args.model)
+    print(transcription_result)
+
+if __name__ == "__main__":
+    main()

--- a/docs/toolkit/cllm-listen.md
+++ b/docs/toolkit/cllm-listen.md
@@ -1,0 +1,75 @@
+# cllm-listen
+
+`cllm-listen` is a command-line interface (CLI) tool designed for recording audio based on volume thresholds. It uses the `sounddevice` and `soundfile` libraries to capture and save audio input to a file. The recording starts when the volume exceeds a specified threshold and stops when the volume remains below the threshold for a certain duration.
+
+## Usage
+
+The CLI tool supports various options to customize the recording process, including specifying the input device, sample rate, number of channels, and volume thresholds.
+
+### Basic Command
+
+To start recording audio, simply run:
+
+```bash
+cllm-listen [options]
+```
+
+### Options
+
+- `-l, --list-devices`: Show a list of available audio devices and exit.
+- `filename`: The name of the audio file to store the recording. If not provided, a temporary file will be created.
+- `-d, --device`: Input device (numeric ID or substring).
+- `-r, --samplerate`: Sampling rate.
+- `-c, --channels`: Number of input channels (default: 1).
+- `-t, --subtype`: Sound file subtype (e.g., "PCM_24").
+- `--threshold`: Volume threshold to start recording (default: 0.7).
+- `--stop-threshold-duration`: Duration in seconds the volume must be below the threshold to stop recording (default: 2.0).
+- `--temp-dir`: Directory for temporary files (default: `${CLLM_DIR}/recordings`).
+- `--temp-prefix`: Prefix for temporary files (default: `voice_chat`).
+
+### Example
+
+To record audio using the default settings and save it to a file named `output.wav`:
+
+```bash
+cllm-listen
+```
+
+To list all available audio devices:
+
+```bash
+cllm-listen --list-devices
+```
+
+To record audio with a specific device and sample rate:
+
+```bash
+cllm-listen -d 1 -r 44100 output.wav
+```
+
+## Configuration
+
+The tool uses environment variables for configuration. You can set these variables in your environment or in a `.env` file.
+
+- `CLLM_DIR`: Directory where temporary files will be stored. Default is `${HOME}/.cllm`.
+
+## Logging
+
+The tool prints status messages and errors to the standard output and standard error streams. This helps in debugging and understanding the recording process.
+
+## Command Line Arguments
+
+- `-l, --list-devices`: Show a list of audio devices and exit.
+- `filename`: The name of the audio file to store the recording. If not provided, a temporary file will be created.
+- `-d, --device`: Input device (numeric ID or substring).
+- `-r, --samplerate`: Sampling rate.
+- `-c, --channels`: Number of input channels (default: 1).
+- `-t, --subtype`: Sound file subtype (e.g., "PCM_24").
+- `--threshold`: Volume threshold to start recording (default: 0.7).
+- `--stop-threshold-duration`: Duration in seconds the volume must be below the threshold to stop recording (default: 2.0).
+- `--temp-dir`: Directory for temporary files (default: `${CLLM_DIR}/recordings`).
+- `--temp-prefix`: Prefix for temporary files (default: `voice_chat`).
+
+## Error Handling
+
+The tool handles exceptions during the recording process and prints error messages to the standard error stream. This ensures that users are informed of any issues that occur during recording.

--- a/docs/toolkit/cllm-speech-text.md
+++ b/docs/toolkit/cllm-speech-text.md
@@ -1,0 +1,46 @@
+# CLLM Speech to Text CLI Tool
+
+This CLI tool allows you to transcribe audio files to text using the LiteLLM library. It supports specifying the audio file and the transcription model to use.
+
+## Usage
+
+The CLI tool supports transcribing an audio file to text.
+
+### Example
+
+```bash
+cllm-speech-text -f path/to/audio/file.wav -m whisper-1
+```
+
+## Command Line Arguments
+
+- `-f, --audio_file`: Path to the audio file for transcription (required).
+- `-m, --model`: Model to use for transcription (default: `whisper-1`).
+
+## Configuration
+
+The tool uses constants defined in the `cllm.constants` module. Ensure that the `CLLM_DIR` is correctly set in your environment or in the constants module.
+
+## Logging
+
+The tool does not include built-in logging. You can add logging as needed by modifying the script.
+
+## Error Handling
+
+The tool handles the following errors:
+- `FileNotFoundError`: If the specified audio file is not found.
+- General exceptions during the transcription process, which are caught and reported.
+
+## Example
+
+To transcribe an audio file located at `./recordings/sample.wav` using the default model `whisper-1`, run:
+
+```bash
+cllm-speech-text -f ./recordings/sample.wav
+```
+
+To specify a different model, for example, `whisper-2`, run:
+
+```bash
+cllm-speech-text -f ./recordings/sample.wav -m whisper-2
+```

--- a/examples/chat/vision.sh
+++ b/examples/chat/vision.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+CHAT_CONTEXT="chat-basic"
+
+echo "When you are done chatting type 'exit' to exit."
+while true; do
+    read -p "$(tput setaf 2)You: $(tput sgr0)" input
+    if [ "$input" == "exit" ]; then
+        break
+    fi
+    echo -n "$(tput setaf 4)Bot: $(tput sgr0)"
+    cllm --streaming -c ${CHAT_CONTEXT} gpt/4o "${input}"
+    echo ""
+done

--- a/examples/chat/voice-vision.sh
+++ b/examples/chat/voice-vision.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+CHAT_CONTEXT="chat-voice"
+
+while true; do
+    echo -ne "Listening...\r"
+    AUDIO_FILE="$(cllm-listen)"
+    echo -ne "Thinking...\r"
+    screencapture -x screenshot.png
+    RESPONSE="$(cllm-speech-text -f "${AUDIO_FILE}" | cllm -i 'screenshot.png' -c "chat-voice" gpt/4)"
+    echo -ne "Talking...\r"
+    echo $RESPONSE | say
+    rm -rf "${AUDIO_FILE}"
+done

--- a/examples/chat/voice.sh
+++ b/examples/chat/voice.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+CHAT_CONTEXT="chat-voice"
+
+while true; do
+    echo -ne "Listening...\r"
+    AUDIO_FILE="$(cllm-listen)"
+    echo -ne "Thinking...\r"
+    RESPONSE="$(cllm-speech-text -f "${AUDIO_FILE}" | cllm -c "chat-voice" groq/llama)"
+    echo -ne "Talking...\r"
+    echo "${RESPONSE}" | say
+    rm -rf "${AUDIO_FILE}"
+done

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cllm"
-version = "0.1.3"
+version = "0.1.9"
 description = "LLM Prompt Chaining in Bash"
 authors = ["owen.zanzal <ozanzal@gmail.com>"]
 license = "MIT"
@@ -26,6 +26,8 @@ unstructured = "^0.14.5"
 webdriver-manager = "^4.0.1"
 litellm = "^1.41.0"
 boto3 = "^1.34.138"
+sounddevice = "^0.5.0"
+soundfile = "^0.12.1"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
@@ -44,3 +46,5 @@ cllm-repeater = 'cllm.toolkit.repeater:main'
 cllm-splitter-docs = 'cllm.toolkit.splitter_docs:main'
 cllm-splitter-text = 'cllm.toolkit.splitter_text:main'
 cllm-vector-faiss = 'cllm.toolkit.vector_faiss:main'
+cllm-speech-text = 'cllm.toolkit.speech_text:main'
+cllm-listen = 'cllm.toolkit.listen:main'


### PR DESCRIPTION
- Introduced `cllm-listen` CLI tool for recording audio based on volume thresholds.
- Implemented `cllm-speech-text` CLI tool for transcribing audio files using the LiteLLM library.
- Updated `cllm` main functionality to include an option to disable writing to chat context.
- Enhanced documentation for both new tools, including usage examples and command-line arguments.
- Added example scripts for voice interaction and integration with chat contexts.
- Updated dependencies in `pyproject.toml` to include `sounddevice` and `soundfile` for audio processing.
- Bumped version to 0.1.9.

closes #27