### PR TITLE
Update README.md: Rename toolkit to CMD | LLM and improve formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Command Line LLM (cllm) Toolkit
+# CMD | LLM (cllm) Command Line Toolkit for LLMs
 
 <p align="center">
   <img src="images/logo.png" width="250">
@@ -7,7 +7,7 @@
 </p>
 
 
-CMD|LLM (cllm) Toolkit is a command line tool for interfacing with LLM models. It is designed to be a simple and easy to use tool for generating text from a prompts. It includes a suite of tools for interfacing with `cllm` output to build more complex prompt chaining processes.
+CMD | LLM (cllm) Toolkit is a command line tool for interfacing with LLM models. It is designed to be a simple and easy to use tool for generating text from a prompts. It includes a suite of tools for interfacing with `cllm` output to build more complex prompt chaining processes.
 
 ## Why?
 


### PR DESCRIPTION
- Changed the title from "Command Line LLM (cllm) Toolkit" to "CMD | LLM (cllm) Command Line Toolkit for LLMs" for clarity and branding.
- Adjusted the description to reflect the new title while maintaining the original intent.